### PR TITLE
Fix feat: open url in customTabintent

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/Reddit-Client.iml" filepath="$PROJECT_DIR$/Reddit-Client.iml" />
       <module fileurl="file://$PROJECT_DIR$/RedditClient.iml" filepath="$PROJECT_DIR$/RedditClient.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>

--- a/app/src/main/java/com/example/dex/redditclient/listings/adapter/ViewAdapter.java
+++ b/app/src/main/java/com/example/dex/redditclient/listings/adapter/ViewAdapter.java
@@ -87,7 +87,6 @@ public class ViewAdapter extends RecyclerView.Adapter<ViewAdapter.ViewHolder> {
                         Context context = v.getContext();
                         CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
                         CustomTabsIntent customTabsIntent = builder.build();
-                        customTabsIntent.intent.setPackage("com.android.chrome");
                         customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                         customTabsIntent.launchUrl(context, Uri.parse(mUrl));
                     }


### PR DESCRIPTION
* I have removed the browser that you've specified. that was for chrom.
* It wasn't working in my device because i don't use chrome, I use firefox.
* It works now that i have removed this line of code from file ViewAdapter.java
* it will ask the user whats its default browser is and use those setting for future. it is more universal this way.

_do let me know if it breaks anything_  I haven't tested it extensively.